### PR TITLE
A bunch of small fixes

### DIFF
--- a/core/src/main/java/eu/bittrade/libs/steemj/base/models/SignedTransaction.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/base/models/SignedTransaction.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.annotations.VisibleForTesting;
 
 import eu.bittrade.libs.steemj.base.models.operations.Operation;
@@ -36,6 +37,7 @@ import eu.bittrade.libs.steemj.util.SteemJUtils;
  * 
  * @author <a href="http://Steemit.com/@dez1337">dez1337</a>
  */
+
 public class SignedTransaction extends Transaction implements ByteTransformable, Serializable {
     private static final long serialVersionUID = 4821422578657270330L;
     private static final Logger LOGGER = LoggerFactory.getLogger(SignedTransaction.class);
@@ -235,6 +237,7 @@ public class SignedTransaction extends Transaction implements ByteTransformable,
      *             If the required private key is not present in the
      *             {@link eu.bittrade.libs.steemj.configuration.PrivateKeyStorage}.
      */
+    @JsonIgnore
     protected List<ECKey> getRequiredSignatureKeys() throws SteemInvalidTransactionException {
         List<ECKey> requiredSignatures = new ArrayList<>();
         Map<SignatureObject, PrivateKeyType> requiredAuthorities = getRequiredAuthorities();

--- a/core/src/main/java/eu/bittrade/libs/steemj/base/models/operations/CommentOptionsOperation.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/base/models/operations/CommentOptionsOperation.java
@@ -404,10 +404,11 @@ public class CommentOptionsOperation extends Operation {
                         "The percent of steem dollars can't be higher than 10000 which is equivalent to 100%.");
             }
 
-            for (CommentOptionsExtension commentOptionsExtension : extensions) {
-                commentOptionsExtension.validate(validationType);
+            if (extensions != null) {
+                for (CommentOptionsExtension commentOptionsExtension : extensions) {
+                    commentOptionsExtension.validate(validationType);
+                }
             }
-
         }
     }
 }

--- a/core/src/main/java/eu/bittrade/libs/steemj/base/models/operations/EscrowApproveOperation.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/base/models/operations/EscrowApproveOperation.java
@@ -203,7 +203,7 @@ public class EscrowApproveOperation extends AbstractEscrowOperation {
 
     @Override
     public void validate(ValidationType validationType) {
-        if (!ValidationType.SKIP_VALIDATION.equals(validationType) && (!who.equals(to) || !who.equals(agent))) {
+        if (!ValidationType.SKIP_VALIDATION.equals(validationType) && !(who.equals(to) || who.equals(agent))) {
             throw new InvalidParameterException(
                     "The to account or the agent account must approve this escrow operation.");
         }

--- a/core/src/main/java/eu/bittrade/libs/steemj/base/models/operations/EscrowTransferOperation.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/base/models/operations/EscrowTransferOperation.java
@@ -113,6 +113,7 @@ public class EscrowTransferOperation extends AbstractEscrowOperation {
         this.setFee(fee);
         this.setRatificationDeadlineDate(ratificationDeadlineDate);
         this.setEscrowExpirationDate(escrowExpirationDate);
+        this.setJsonMeta(jsonMeta);
     }
 
     /**


### PR DESCRIPTION
Added some small fixes after testing with the Android app. Some comments:

Commit dff2227e1522657c45dee020f61c43f31bfec1a7 - if comment extensions field is null there is an exception - which shouldn't be, cause null is legal there. Another way to fix is to change "extensions" to "getExtensions()" - maybe it's more OO-way :)

Commit 34d2ce4b1ac0aa742f479a316770fb069431326f - for some reason I have a wierd exception when geting global properties:
```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.spongycastle.math.ec.ScaleXPointMap and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: eu.bittrade.libs.steemj.communication.dto.RequestWrapperDTO["params"]->java.lang.Object[][2]->eu.bittrade.libs.steemj.base.models.SignedTransaction[0]->eu.bittrade.libs.steemj.base.models.SignedTransaction["requiredSignatureKeys"]->java.util.ArrayList[0]->org.bitcoinj.core.ECKey["pubKeyPoint"]->org.spongycastle.math.ec.custom.sec.SecP256K1Point["curve"]->org.spongycastle.math.ec.custom.sec.SecP256K1Curve["endomorphism"]->org.spongycastle.math.ec.endo.GLVTypeBEndomorphism["pointMap"])
```
(the more detailed descriptions is in the comments thread to the issue #64).
Seems that nobody except me have that exception, but just to be on the safe side I added an instruction to the Jackson Databind to ignore this property...