### PR TITLE
Hyphenated permlinks

### DIFF
--- a/core/src/main/java/eu/bittrade/libs/steemj/SteemJ.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/SteemJ.java
@@ -2969,7 +2969,7 @@ public class SteemJ {
 
         // Generate the permanent link from the title by replacing all unallowed
         // characters.
-        Permlink permlink = new Permlink(title.toLowerCase().replaceAll("[^a-z0-9-]+", ""));
+        Permlink permlink = new Permlink(SteemJUtils.createPermlinkString(title));
         // On new posts the parentPermlink is the main tag.
         Permlink parentPermlink = new Permlink(tags[0]);
         // One new posts the parentAuthor is empty.

--- a/core/src/main/java/eu/bittrade/libs/steemj/util/SteemJUtils.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/util/SteemJUtils.java
@@ -326,4 +326,25 @@ public class SteemJUtils {
 
         return signedTransaction;
     }
+
+    /**
+     * Create a permlink string from the given <code>title</code>:
+     * <ol>
+     *     <li>The title is trimmed and converted to lowercase</li>
+     *     <li>Spaces are converted to hyphens</li>
+     *     <li>Disallowed characters are removed</li>
+     *     <li>Contiguous hyphens are replaced with a singe hyphen</li>
+     * </ol>
+     *
+     * @param title
+     *          The string to covert
+     * @return The generated permlink
+     */
+    public static String createPermlinkString(String title) {
+        return title
+                .trim().toLowerCase()
+                .replaceAll(" ", "-")
+                .replaceAll("[^a-z0-9-]+", "")
+                .replaceAll("-+", "-");
+    }
 }

--- a/core/src/test/java/eu/bittrade/libs/steemj/util/SteemJUtilsTest.java
+++ b/core/src/test/java/eu/bittrade/libs/steemj/util/SteemJUtilsTest.java
@@ -1,5 +1,6 @@
 package eu.bittrade.libs.steemj.util;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -25,5 +26,21 @@ public class SteemJUtilsTest {
                 + "{ \"menuitem\": [ {\"value\": \"New\", \"onclick\": \"CreateNewDoc()\"}, "
                 + "{\"value\": \"Open\", \"onclick\": \"OpenDoc()\"},"
                 + "{\"value\": [\"Close\",] \"onclick\": \"CloseDoc()\"}]}}"));
+    }
+
+    /**
+     * Test if the {@link SteemJUtils#createPermlinkString(String)} method is
+     * working correctly.
+     */
+    @Test
+    public void testCreatePermlinkString() {
+        // Check trimming, lowercasing, space replacement
+        assertEquals("test-title-1", SteemJUtils.createPermlinkString(" TEST TITLE 1 "));
+
+        // Only numbers, letters and hyphens allowed
+        assertEquals("test-title-2", SteemJUtils.createPermlinkString("TEST TITLE 2!"));
+
+        // Contiguous hyphens should be replaced with a single hyphen
+        assertEquals("test-title-3", SteemJUtils.createPermlinkString("TEST TITLE  3"));
     }
 }


### PR DESCRIPTION
Hyphens now used to separate words in permlinks. For example "Post Title" would now have permlink "post-title".