### PR TITLE
Remove dot in account name when building the permlink for comments

### DIFF
--- a/core/src/main/java/eu/bittrade/libs/steemj/SteemJ.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/SteemJ.java
@@ -3170,7 +3170,7 @@ public class SteemJ {
 
         // Generate the permanent link by adding the current timestamp and a
         // UUID.
-        Permlink permlink = new Permlink("re-" + authorOfThePostOrCommentToReplyTo.getName() + "-"
+        Permlink permlink = new Permlink("re-" + authorOfThePostOrCommentToReplyTo.getName().replaceAll("\\.", "") + "-"
                 + permlinkOfThePostOrCommentToReplyTo.getLink() + "-" + System.currentTimeMillis() + "t"
                 + UUID.randomUUID().toString() + "uid");
 


### PR DESCRIPTION
Hello This is my first contribution to SteemJ, small one.

We are using SteemJ for [SteemitWorldMap](http://www.steemitworldmap.com). We recently found out that autocomment are failing on user contaning a dot in the account name.

This issue is that the generated permlink for the reply also contains a dot character, rendering it invalid by the permlink validator.

Form what I see in the condenser interface, it is removing the dot character. I implemented the same behavior in this PR. This should be the only character to removing since account names can only contain alphanumerical characters + dot.

Here is a simple test to reproduce the issue :
```
	@Test
	public void comment() throws Exception {
		new SteemJ().createComment(new AccountName("malik.roxane"), new Permlink("colorchallenge-make-it-like-a-sunflower"), "SteemJ test", new String[]{ "test", "steemj" });
	}
```

[As you can see here](https://steemit.com/colorchallenge/@malik.roxane/colorchallenge-make-it-like-a-sunflower#@roxane/re-malikroxane-colorchallenge-make-it-like-a-sunflower-1514654873149tabea01d8-a41f-4b03-bb08-33640dcbbdc0uid), applying this pull request fixes the issue and allows the comment as expected.