### PR TITLE
Should use String or Int for BigDecimal value

### DIFF
--- a/sample/src/main/java/my/sample/project/SteemJUsageExample.java
+++ b/sample/src/main/java/my/sample/project/SteemJUsageExample.java
@@ -126,7 +126,7 @@ public class SteemJUsageExample {
             /*
              * Let the default account transfer 1.0 SBD to @dez1337.
              */
-            steemJ.transfer(new AccountName("dez1337"), new Asset(new BigDecimal(1.0), AssetSymbolType.STEEM), "Hello @dez1337 - I've send you one STEEM.");
+            steemJ.transfer(new AccountName("dez1337"), new Asset(new BigDecimal("1.000"), AssetSymbolType.STEEM), "Hello @dez1337 - I've send you one STEEM.");
             
             /*
              * Let the default account delegate 10.0 VESTS to @dez1337.


### PR DESCRIPTION
Should use string and not double or float when constructing a BigDecimal to prevent floating point errors from getting introduced.
Or use a long or int combined with a decimal shift operation: new BigDecimal("1.001") or new BigDecimal(1001).movePointLeft(3);